### PR TITLE
Made the cancellation widget's area next to the search bar more dynamic.

### DIFF
--- a/lib/flappy_search_bar.dart
+++ b/lib/flappy_search_bar.dart
@@ -31,7 +31,8 @@ class SearchBarController<T> {
   CancelableOperation _cancelableOperation;
   int minimumChars;
 
-  void setTextController(TextEditingController _searchQueryController, minimunChars) {
+  void setTextController(
+      TextEditingController _searchQueryController, minimunChars) {
     this._searchQueryController = _searchQueryController;
     this.minimumChars = minimunChars;
   }
@@ -215,38 +216,43 @@ class SearchBar<T> extends StatefulWidget {
   /// Set a padding on the list
   final EdgeInsetsGeometry listPadding;
 
-  SearchBar({
-    Key key,
-    @required this.onSearch,
-    @required this.onItemFound,
-    this.searchBarController,
-    this.minimumChars = 3,
-    this.debounceDuration = const Duration(milliseconds: 500),
-    this.loader = const Center(child: CircularProgressIndicator()),
-    this.onError,
-    this.emptyWidget = const SizedBox.shrink(),
-    this.header,
-    this.placeHolder,
-    this.icon = const Icon(Icons.search),
-    this.hintText = "",
-    this.hintStyle = const TextStyle(color: Color.fromRGBO(142, 142, 147, 1)),
-    this.iconActiveColor = Colors.black,
-    this.textStyle = const TextStyle(color: Colors.black),
-    this.cancellationWidget = const Text("Cancel"),
-    this.onCancelled,
-    this.suggestions = const [],
-    this.buildSuggestion,
-    this.searchBarStyle = const SearchBarStyle(),
-    this.crossAxisCount = 1,
-    this.shrinkWrap = false,
-    this.indexedScaledTileBuilder,
-    this.scrollDirection = Axis.vertical,
-    this.mainAxisSpacing = 0.0,
-    this.crossAxisSpacing = 0.0,
-    this.listPadding = const EdgeInsets.all(0),
-    this.searchBarPadding = const EdgeInsets.all(0),
-    this.headerPadding = const EdgeInsets.all(0),
-  }) : super(key: key);
+  /// The space in the width of the space bar to
+  /// allocate for the cancellation widget.
+  final double cancellationWidgetSpaceWidth;
+
+  SearchBar(
+      {Key key,
+      @required this.onSearch,
+      @required this.onItemFound,
+      this.searchBarController,
+      this.minimumChars = 3,
+      this.debounceDuration = const Duration(milliseconds: 500),
+      this.loader = const Center(child: CircularProgressIndicator()),
+      this.onError,
+      this.emptyWidget = const SizedBox.shrink(),
+      this.header,
+      this.placeHolder,
+      this.icon = const Icon(Icons.search),
+      this.hintText = "",
+      this.hintStyle = const TextStyle(color: Color.fromRGBO(142, 142, 147, 1)),
+      this.iconActiveColor = Colors.black,
+      this.textStyle = const TextStyle(color: Colors.black),
+      this.cancellationWidget = const Text("Cancel"),
+      this.onCancelled,
+      this.suggestions = const [],
+      this.buildSuggestion,
+      this.searchBarStyle = const SearchBarStyle(),
+      this.crossAxisCount = 1,
+      this.shrinkWrap = false,
+      this.indexedScaledTileBuilder,
+      this.scrollDirection = Axis.vertical,
+      this.mainAxisSpacing = 0.0,
+      this.crossAxisSpacing = 0.0,
+      this.listPadding = const EdgeInsets.all(0),
+      this.searchBarPadding = const EdgeInsets.all(0),
+      this.headerPadding = const EdgeInsets.all(0),
+      this.cancellationWidgetSpaceWidth})
+      : super(key: key);
 
   @override
   _SearchBarState createState() => _SearchBarState<T>();
@@ -268,7 +274,8 @@ class _SearchBarState<T> extends State<SearchBar<T>>
     searchBarController =
         widget.searchBarController ?? SearchBarController<T>();
     searchBarController.setListener(this);
-    searchBarController.setTextController(_searchQueryController, widget.minimumChars);
+    searchBarController.setTextController(
+        _searchQueryController, widget.minimumChars);
   }
 
   @override
@@ -373,6 +380,12 @@ class _SearchBarState<T> extends State<SearchBar<T>>
 
   @override
   Widget build(BuildContext context) {
+    double _getCancellationWidth() {
+      return (widget.cancellationWidgetSpaceWidth != null
+          ? widget.cancellationWidgetSpaceWidth
+          : MediaQuery.of(context).size.width * .2);
+    }
+
     final widthMax = MediaQuery.of(context).size.width;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -387,7 +400,9 @@ class _SearchBarState<T> extends State<SearchBar<T>>
                 Flexible(
                   child: AnimatedContainer(
                     duration: Duration(milliseconds: 200),
-                    width: _animate ? widthMax * .8 : widthMax,
+                    width: _animate
+                        ? widthMax - _getCancellationWidth()
+                        : widthMax,
                     decoration: BoxDecoration(
                       borderRadius: widget.searchBarStyle.borderRadius,
                       color: widget.searchBarStyle.backgroundColor,
@@ -421,8 +436,7 @@ class _SearchBarState<T> extends State<SearchBar<T>>
                     duration: Duration(milliseconds: _animate ? 1000 : 0),
                     child: AnimatedContainer(
                       duration: Duration(milliseconds: 200),
-                      width:
-                          _animate ? MediaQuery.of(context).size.width * .2 : 0,
+                      width: _animate ? _getCancellationWidth() : 0,
                       child: Container(
                         color: Colors.transparent,
                         child: Center(


### PR DESCRIPTION
Basically I used an Icon widget instead of a text widget and found that there was way too much space on either side of the widget. The change I made gets the width of the cancellation widget, adds a little bit of padding to the left and right, and then makes the total width plus padding the space taken away from the search bar for the cancellation widget. 

_NOTE: The image below is using my updated code but I just adjusted the padding to illustrate close to what it looked like before._
![image](https://user-images.githubusercontent.com/42769125/73589057-2de30c00-450c-11ea-8626-162d3d46ff0e.png)
As you can see in the image above there was too much space on either side. The changes I've made just makes it a little better:
![image](https://user-images.githubusercontent.com/42769125/73589069-54a14280-450c-11ea-89f9-551d70122119.png)
