### PR TITLE
Add autofocus property to SearchBar

### DIFF
--- a/lib/flappy_search_bar.dart
+++ b/lib/flappy_search_bar.dart
@@ -215,6 +215,9 @@ class SearchBar<T> extends StatefulWidget {
   /// Set a padding on the list
   final EdgeInsetsGeometry listPadding;
 
+  // Focus when the page loads?
+  final bool autofocus;
+
   SearchBar({
     Key key,
     @required this.onSearch,
@@ -246,6 +249,7 @@ class SearchBar<T> extends StatefulWidget {
     this.listPadding = const EdgeInsets.all(0),
     this.searchBarPadding = const EdgeInsets.all(0),
     this.headerPadding = const EdgeInsets.all(0),
+	this.autofocus = false,
   }) : super(key: key);
 
   @override
@@ -396,6 +400,7 @@ class _SearchBarState<T> extends State<SearchBar<T>>
                       padding: widget.searchBarStyle.padding,
                       child: Theme(
                         child: TextField(
+						  autofocus: widget.autofocus,
                           controller: _searchQueryController,
                           onChanged: _onTextChanged,
                           style: widget.textStyle,

--- a/lib/flappy_search_bar.dart
+++ b/lib/flappy_search_bar.dart
@@ -249,7 +249,7 @@ class SearchBar<T> extends StatefulWidget {
     this.listPadding = const EdgeInsets.all(0),
     this.searchBarPadding = const EdgeInsets.all(0),
     this.headerPadding = const EdgeInsets.all(0),
-	this.autofocus = false,
+    this.autofocus = false,
   }) : super(key: key);
 
   @override
@@ -400,7 +400,7 @@ class _SearchBarState<T> extends State<SearchBar<T>>
                       padding: widget.searchBarStyle.padding,
                       child: Theme(
                         child: TextField(
-						  autofocus: widget.autofocus,
+                          autofocus: widget.autofocus,
                           controller: _searchQueryController,
                           onChanged: _onTextChanged,
                           style: widget.textStyle,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flappy_search_bar
 description: A SearchBar widget automatizing most of your asynchronous searchs cases.
-version: 1.7.2
+version: 1.7.2-dev1
 homepage: https://github.com/smartnsoft/flappy_search_bar
 
 environment:


### PR DESCRIPTION
Hey, thanks so much for creating this widget. It's perfect for what I need!

In this PR, I expose the "autofocus" property of the underlying `TextField` by adding it as a property of the SearchBar class and passing it through.

I just tested it out on the app I'm using this on, and it seems to work fine. When I navigate to the page with `autofocus: true`, the keyboard immediately opens, ready to type. 🙂

Let me know if you think this is a useful addition! Feel free to request changes.

Thanks!